### PR TITLE
Limit allowed Saleor domains

### DIFF
--- a/src/saleor_mcp/config.py
+++ b/src/saleor_mcp/config.py
@@ -1,6 +1,6 @@
 import os
-import re
 from dataclasses import dataclass
+from fnmatch import fnmatch
 
 from fastmcp.exceptions import ToolError
 from fastmcp.server.dependencies import get_http_headers
@@ -8,9 +8,7 @@ from fastmcp.server.dependencies import get_http_headers
 
 def validate_api_url(url, pattern):
     """Validate if the given URL matches the allowed domain pattern."""
-    regex_pattern = pattern.replace("*", ".*")
-    regex = re.compile(f"^{regex_pattern}$")
-    return bool(regex.match(url))
+    return fnmatch(url, pattern)
 
 
 @dataclass

--- a/src/saleor_mcp/tests/test_config.py
+++ b/src/saleor_mcp/tests/test_config.py
@@ -11,6 +11,7 @@ from saleor_mcp.config import get_config_from_headers, validate_api_url
         ("https://example.saleor.cloud", "https://*.saleor.cloud", True),
         ("https://sub.domain.saleor.cloud", "https://*.saleor.cloud", True),
         ("https://other.saleor.cloud", "https://exact.saleor.cloud", False),
+        ("https://malicious-saleor.cloud", "https://*.saleor.cloud", False),
     ],
 )
 def test_validate_api_url(url, pattern, expected):


### PR DESCRIPTION
Add the env variable `ALLOWED_DOMAIN_PATTERN` to limit allowed Saleor API domains to a given regex pattern. Example value would be `https://*.saleor.cloud/graphql/` 