### PR TITLE
feat: switch Dockerfile uvicorn command to ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ LABEL org.opencontainers.image.title="saleor/saleor-mcp" \
     org.opencontainers.image.authors="Saleor Commerce (https://saleor.io)" \
     org.opencontainers.image.licenses="AGPL-3.0"
 
-CMD ["uvicorn", "saleor_mcp.main:app", "--host", "0.0.0.0", "--port", "8000"]
+ENTRYPOINT ["uvicorn", "saleor_mcp.main:app", "--host=0.0.0.0", "--port=8000"]


### PR DESCRIPTION
This replaces `CMD` for `uvicorn saleor_mcp.main:app --host 0.0.0.0 --port 8000` with `ENTRYPOINT` in order to make it easier for users to customize how the uvicorn server should be started.

ENTRYPOINT should only contain generic arguments that should not be changed.

Before the change, we had to do the following to add 1 argument to the uvicorn server:

```
docker run saleor-mcp uvicorn saleor_mcp.main:app --host 0.0.0.0 --port 8000 --workers=4
```

After the change, the command is the following:

```
docker run saleor-mcp --workers=4
```

This removes the need to copy/paste the original command from the Dockerfile, and ensures that the uvicorn command is never outdated (e.g., in helm charts) as users will not maintain a copy of the Dockerfile command, thus any changes to the ENTRYPOINT in the `Dockerfile` will automatically be reflected to users.