### PR TITLE
Use stateless HTTP

### DIFF
--- a/src/saleor_mcp/main.py
+++ b/src/saleor_mcp/main.py
@@ -37,7 +37,7 @@ async def index(request: Request):
     return HTMLResponse(content)
 
 
-app = mcp.http_app()
+app = mcp.http_app(stateless_http=True)
 
 
 def main():


### PR DESCRIPTION
Sessions complicate the production deployment because they require session stickiness in ALB. Since we're not yet sure about the use cases of sessions and whether they're useful for us, the server will run in stateless mode.