### PR TITLE
Adjust input params

### DIFF
--- a/src/saleor_mcp/config.py
+++ b/src/saleor_mcp/config.py
@@ -8,6 +8,7 @@ from fastmcp.server.dependencies import get_http_headers
 
 LOGLEVEL = os.environ.get("LOGLEVEL", "INFO").upper()
 logging.basicConfig(level=LOGLEVEL)
+logging.getLogger("mcp.server.streamable_http").setLevel(logging.WARNING)
 
 
 def validate_api_url(url, pattern):

--- a/src/saleor_mcp/main.py
+++ b/src/saleor_mcp/main.py
@@ -1,4 +1,5 @@
 from fastmcp import FastMCP
+from fastmcp.server.middleware.timing import DetailedTimingMiddleware
 from starlette.requests import Request
 from starlette.responses import FileResponse, JSONResponse
 from starlette.staticfiles import StaticFiles
@@ -11,6 +12,7 @@ from saleor_mcp.tools import (
 )
 
 mcp = FastMCP("Saleor MCP Server")
+mcp.add_middleware(DetailedTimingMiddleware())
 mcp.mount(channels_router)
 mcp.mount(orders_router)
 mcp.mount(products_router)

--- a/src/saleor_mcp/tools/customers.py
+++ b/src/saleor_mcp/tools/customers.py
@@ -1,11 +1,20 @@
-from typing import Annotated, Any
+from typing import Annotated, Any, Optional
 
 from fastmcp import Context, FastMCP
 
 from ..ctx_utils import get_saleor_client
-from ..saleor_client.input_types import CustomerWhereInput, UserSortingInput
+from ..saleor_client.base_model import BaseModel
+from ..saleor_client.input_types import (
+    DateTimeRangeInput,
+    UserSortingInput,
+)
 
 customers_router = FastMCP("Customers MCP")
+
+
+class CustomerWhereInput(BaseModel):
+    dateJoined: Optional["DateTimeRangeInput"] = None
+    updatedAt: Optional["DateTimeRangeInput"] = None
 
 
 @customers_router.tool(

--- a/src/saleor_mcp/tools/orders.py
+++ b/src/saleor_mcp/tools/orders.py
@@ -1,11 +1,20 @@
-from typing import Annotated, Any
+from typing import Annotated, Any, Optional
 
 from fastmcp import Context, FastMCP
 
 from ..ctx_utils import get_saleor_client
-from ..saleor_client.input_types import OrderSortingInput, OrderWhereInput
+from ..saleor_client.base_model import BaseModel
+from ..saleor_client.input_types import (
+    DateTimeRangeInput,
+    OrderSortingInput,
+)
 
 orders_router = FastMCP("Orders MCP")
+
+
+class OrderWhereInput(BaseModel):
+    createdAt: Optional["DateTimeRangeInput"] = None
+    updatedAt: Optional["DateTimeRangeInput"] = None
 
 
 @orders_router.tool(
@@ -30,6 +39,7 @@ async def orders(
     where: Annotated[
         OrderWhereInput | None, "Filter orders by specific criteria"
     ] = None,
+    search: Annotated[str | None, "Search orders by term"] = None,
 ) -> dict[str, Any]:
     """Fetch list of orders from Saleor GraphQL API.
 
@@ -44,6 +54,8 @@ async def orders(
         after (str | None): Cursor for pagination - fetch orders after this cursor.
         sort_by (OrderSortingInput | None): Sort orders by specific field.
         where (OrderWhereInput | None): Filter orders by specific criteria.
+        search (str | None): Search orders by term such as order number, ID, user
+            email, first name, or last name or address.
 
     """
 

--- a/src/saleor_mcp/tools/products.py
+++ b/src/saleor_mcp/tools/products.py
@@ -5,7 +5,6 @@ from fastmcp import Context, FastMCP
 from ..ctx_utils import get_saleor_client
 from ..saleor_client.input_types import (
     ProductOrder,
-    ProductWhereInput,
     StockFilterInput,
 )
 
@@ -33,9 +32,6 @@ async def products(
         "Slug of a channel for which the data should be returned. If not provided, "
         "general product data is returned.",
     ] = None,
-    where: Annotated[
-        ProductWhereInput | None, "Filter products by specific criteria"
-    ] = None,
     sortBy: Annotated[ProductOrder | None, "Sort products by specific field"] = None,
     search: Annotated[str | None, "Search products with full-text search"] = None,
 ) -> dict[str, Any]:
@@ -51,7 +47,6 @@ async def products(
 
     """
 
-    where = where.model_dump(exclude_unset=True) if where else None
     sort_by = sortBy.model_dump(exclude_unset=True) if sortBy else None
 
     data = {}
@@ -61,7 +56,6 @@ async def products(
             first=first,
             after=after,
             channel=channel,
-            where=where,
             sortBy=sort_by,
             search=search,
         )

--- a/src/saleor_mcp/tools/utils.py
+++ b/src/saleor_mcp/tools/utils.py
@@ -1,5 +1,3 @@
-from datetime import UTC, datetime
-
 from fastmcp import FastMCP
 
 from ..config import get_config_from_headers
@@ -13,10 +11,3 @@ def current_domain() -> str:
 
     headers = get_config_from_headers()
     return headers.api_url
-
-
-@utils_router.tool()
-def current_date_time() -> str:
-    """Return the current date and time in ISO 8601 format in UTC timezone."""
-
-    return datetime.now(UTC).isoformat()


### PR DESCRIPTION
Bunch of changes after recent testing:
- While the current shape of tools gives a lot of flexibility to LLMs in filtering data by numerous criteria, the size of the resulting JSON schema is quite large (over 120k characters right now). This is caused by duplication of many input definitions that are redefined for each tool in the schema. I'll be exploring this problem deeper, but for now, I simplified the arguments and either removed some `where` filters in favor of `search`, or simplified `where` to include only basic filtering by dates. As a result, the schema is around 20k characters, which I still consider large, but helps working with LLM and not consuming token limits so quickly as before.
- Removed the `current_date_time` tool, since it can be easily defined as "static" tools ([example](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling)).
- Added `DetailedTimingMiddleware`, which produces logs tracking the duration of tool calls. This will be useful until we provide actual observability with OpenTelemetry in the future.