### PR TITLE
fix: syntax error in deployment workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,5 +78,6 @@ jobs:
                 "image_tag": $image_tag
               }
             }'
+          )
 
           gh api /repos/saleor/saleor-cloud-deployments/dispatches --input <(echo "$payload")


### PR DESCRIPTION
Fixes a missing closing `)` introduced by https://github.com/saleor/saleor-mcp/pull/22