### PR TITLE
chore: upgrade Starlette to v1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "python-json-logger>=3.3.0",
     "jinja2>=3.1.0",
     "ty>=0.0.5",
+    "starlette>=1.0.1",
 ]
 
 [build-system]
@@ -40,8 +41,9 @@ exclude-newer = "3 weeks"
 [tool.uv.exclude-newer-package]
 # To customize on a per-package basis, for example you can do this:
 # django = "2026-04-07T14:30:00Z"
-pyjwt = "2026-05-21T19:54:36" # https://github.com/jpadilla/pyjwt/releases/tag/2.13.0
-idna = "2026-05-12T22:45:57" # https://github.com/advisories/GHSA-65pc-fj4g-8rjx/
+pyjwt = "2026-05-21T19:54:36Z" # https://github.com/jpadilla/pyjwt/releases/tag/2.13.0
+idna = "2026-05-12T22:45:57Z" # https://github.com/advisories/GHSA-65pc-fj4g-8rjx/
+starlette = "2026-05-21T21:58:58Z" # https://github.com/Kludex/starlette/security/advisories/GHSA-86qp-5c8j-p5mr
 
 [tool.ariadne-codegen]
 schema_path = "./schema.graphql"

--- a/uv.lock
+++ b/uv.lock
@@ -7,8 +7,9 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P3W"
 
 [options.exclude-newer-package]
-pyjwt = "2026-05-22T00:00:00Z"
-idna = "2026-05-13T00:00:00Z"
+starlette = "2026-05-21T21:58:58Z"
+pyjwt = "2026-05-21T19:54:36Z"
+idna = "2026-05-12T22:45:57Z"
 
 [[package]]
 name = "annotated-types"
@@ -1556,6 +1557,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "pydantic" },
     { name = "python-json-logger" },
+    { name = "starlette" },
     { name = "ty" },
     { name = "uvicorn" },
 ]
@@ -1580,6 +1582,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "python-json-logger", specifier = ">=3.3.0" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "ty", specifier = ">=0.0.5" },
     { name = "uvicorn", specifier = ">=0.24.0" },
 ]
@@ -1672,15 +1675,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.49.1"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/3f/507c21db33b66fb027a332f2cb3abbbe924cc3a79ced12f01ed8645955c9/starlette-0.49.1.tar.gz", hash = "sha256:481a43b71e24ed8c43b11ea02f5353d77840e01480881b8cb5a26b8cae64a8cb", size = 2654703, upload-time = "2025-10-28T17:34:10.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/da/545b75d420bb23b5d494b0517757b351963e974e79933f01e05c929f20a6/starlette-0.49.1-py3-none-any.whl", hash = "sha256:d92ce9f07e4a3caa3ac13a79523bd18e3bc0042bb8ff2d759a8e7dd0e1859875", size = 74175, upload-time = "2025-10-28T17:34:09.13Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes [CVE-2026-48710](https://github.com/Kludex/starlette/security/advisories/GHSA-86qp-5c8j-p5mr) by upgrading to latest.

Part of ENG-1602