### PR TITLE
build: pin uv version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 FROM python:3.12 AS build-python
 
 WORKDIR /app
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY \
+  --from=ghcr.io/astral-sh/uv:0.11.8@sha256:3b7b60a81d3c57ef471703e5c83fd4aaa33abcd403596fb22ab07db85ae91347 \
+  /uv /uvx /bin/
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
 
 COPY . /app


### PR DESCRIPTION
The uv version was not pinned in Dockerfile which is supplychain concern. We follow a 21 day cooldown.